### PR TITLE
Bug/double close

### DIFF
--- a/examples/streaming/stream.go
+++ b/examples/streaming/stream.go
@@ -75,4 +75,6 @@ func main() {
 
 	}
 
+	conn.Close()
+
 }

--- a/stream.go
+++ b/stream.go
@@ -137,7 +137,6 @@ func (c *Conn) Write(r io.Reader) error {
 func (c *Conn) Recv() (*StreamMessage, error) {
 	select {
 	case err := <-c.err:
-		defer close(c.err)
 		if e, ok := err.(*websocket.CloseError); ok {
 			if e.Code == 1000 {
 				return nil, io.EOF
@@ -212,6 +211,7 @@ func (s *StreamService) Dial(ctx context.Context, params *DialStreamParams) (*Co
 	go func() {
 		defer conn.Close()
 		// close msg channel as we wont be writing any more
+		defer close(conn.err)
 		defer close(conn.msg)
 		defer func() {
 			if r := recover(); r != nil {

--- a/stream.go
+++ b/stream.go
@@ -163,9 +163,8 @@ func (c *Conn) WriteDone() error {
 	return c.conn.WriteMessage(websocket.TextMessage, []byte("EOS"))
 }
 
-// Close closes the message chan and the websocket connection
+// Close closes the websocket connection
 func (c *Conn) Close() error {
-	close(c.msg)
 
 	return c.conn.Close()
 }
@@ -217,6 +216,8 @@ func (s *StreamService) Dial(ctx context.Context, params *DialStreamParams) (*Co
 
 	go func() {
 		defer conn.Close()
+		// close msg channel as we wont be writing any more
+		defer close(conn.msg)
 		for {
 			var msg StreamMessage
 			if err := conn.conn.ReadJSON(&msg); err != nil {


### PR DESCRIPTION
fix https://github.com/threeaccents/revai-go/issues/11

When we only have one sender we should let the sender close the channel when it is done. As explained in https://go101.org/article/channel-closing.html

Closing the socket will finish trigger the read loop to finish.

Creating as a draft as I haven't tested this fix.