### PR TITLE
TranscriptService: Fix GetText return type

### DIFF
--- a/transcript.go
+++ b/transcript.go
@@ -73,7 +73,7 @@ func (s *TranscriptService) GetText(ctx context.Context, params *GetTranscriptPa
 		return nil, fmt.Errorf("failed creating request %w", err)
 	}
 
-	req.Header.Add("Accept", RevTranscriptJSONHeader)
+	req.Header.Add("Accept", TextPlainHeader)
 
 	resp, err := s.client.do(ctx, req)
 	if err != nil {


### PR DESCRIPTION
We need to send `TextPlainHeader` in the Accept header to correctly return the plain text version of the transcription, instead of `RevTranscriptJSONHeader` which makes the plain text response to be a json payload